### PR TITLE
Setup do background funcionando (i.e. dependências de plugins resolvi…

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -34,9 +34,21 @@ class local_tutores_base_group {
      * @return array
      */
     static function get_papeis_estudantes() {
-        global $CFG;
 
-        return explode(',', $CFG->local_tutores_student_roles);
+        global $DB;
+
+        $sql = "SELECT value
+                FROM config
+                WHERE name = :local_tutores_student_roles";
+
+        $params = array('local_tutores_student_roles' => 'local_tutores_student_roles');
+
+        $student = $DB->get_record_sql($sql, $params);
+
+        return $student->value;
+//        global $CFG;
+
+//        return explode(',', $CFG->local_tutores_student_roles);
     }
 
     /**
@@ -464,9 +476,20 @@ class local_tutores_grupos_tutoria extends local_tutores_base_group {
      * @return array
      */
     static function get_papeis_tutores() {
-        global $CFG;
+        global $DB;
 
-        return explode(',', $CFG->local_tutores_tutor_roles);
+        $sql = "SELECT value
+                FROM {config}
+                WHERE name = :local_tutores_tutor_roles";
+
+        $params = array('local_tutores_tutor_roles' => 'local_tutores_tutor_roles');
+
+        $teacher =  $DB->get_record_sql($sql, $params);
+
+        return $teacher->value;
+//        global $CFG;
+//
+//        return explode(',', $CFG->local_tutores_tutor_roles);
     }
 
     /**
@@ -622,6 +645,7 @@ class local_tutores_grupos_tutoria extends local_tutores_base_group {
         global $DB;
 
         $tutor_role = local_tutores_grupos_tutoria::get_papeis_tutores();
+
         list($sqlfragment, $paramsfragment) = $DB->get_in_or_equal($tutor_role, SQL_PARAMS_NAMED, 'shortname');
 
         $sql = "SELECT rc.*
@@ -631,8 +655,8 @@ class local_tutores_grupos_tutoria extends local_tutores_base_group {
                  WHERE relationshipid=:relationship_id
                    AND r.shortname {$sqlfragment}";
 
-
         $params = array_merge($paramsfragment, array('relationship_id' => $relationship_id));
+
         $cohort = $DB->get_record_sql($sql, $params);
 
         if (!$cohort) {

--- a/middlewarelib.php
+++ b/middlewarelib.php
@@ -72,11 +72,21 @@ class Middleware {
         }
 
         // Configura padrões de substituição de nomes de tabelas no SQL
-        self::$patterns = array(
-            '/\{view_([a-zA-Z][0-9a-zA-Z_]*)\}/i' => $config->dbname . '.View_' . $config->contexto . '_$1',
-            '/\{geral_([a-zA-Z][0-9a-zA-Z_]*)\}/i' => $config->dbname . '.View_Geral_$1',
-            '/\{table_([a-zA-Z][0-9a-zA-Z_]*)\}/i' => $config->dbname . '.$1',
-            '/\{([a-z][a-z0-9_]*)\}/' => $moodle_prefix.'$1'); // regexp do moodle, precisa ser o útlimo
+        if(strpos($moodle_prefix , $CFG->behat_prefix)){
+            //Workaround para aceitação de testes de comportamento behat
+            //(Retirada do ponto na variável $1 no último índice)
+            self::$patterns = array(
+                '/\{view_([a-zA-Z][0-9a-zA-Z_]*)\}/i' => $config->dbname . '.View_' . $config->contexto . '_$1',
+                '/\{geral_([a-zA-Z][0-9a-zA-Z_]*)\}/i' => $config->dbname . '.View_Geral_$1',
+                '/\{table_([a-zA-Z][0-9a-zA-Z_]*)\}/i' => $config->dbname . '.$1',
+                '/\{([a-z][a-z0-9_]*)\}/' => $moodle_prefix . '$1'); // regexp do moodle, precisa ser o útlimo
+        }else{
+            self::$patterns = array(
+                '/\{view_([a-zA-Z][0-9a-zA-Z_]*)\}/i' => $config->dbname . '.View_' . $config->contexto . '_$1',
+                '/\{geral_([a-zA-Z][0-9a-zA-Z_]*)\}/i' => $config->dbname . '.View_Geral_$1',
+                '/\{table_([a-zA-Z][0-9a-zA-Z_]*)\}/i' => $config->dbname . '.$1',
+                '/\{([a-z][a-z0-9_]*)\}/' => $moodle_prefix . '.$1'); // regexp do moodle, precisa ser o útlimo
+        }
 
         // Inicializa conexão com a base de dados
         $db = $this->db_init($config);
@@ -232,7 +242,12 @@ class Middleware {
         $externaldb = ADONewConnection($CFG->dbtype);
 
         // Considerando os dados de conexão do config.php e apenas alterando o dbname pelas configurações do plugin.
-        $externaldb->Connect($CFG->dbhost, $CFG->dbuser, $CFG->dbpass, $config->dbname, true);
+        if(empty($CFG->dboptions['dbport'])) {
+            // Condição necessária caso necessite especificar uma porta do database
+            $externaldb->Connect($CFG->dbhost, $CFG->dbuser, $CFG->dbpass, $config->dbname, true);
+        }else {
+            $externaldb->Connect($CFG->dbhost . ":" . $CFG->dboptions['dbport'], $CFG->dbuser, $CFG->dbpass, $config->dbname, true);
+        }
         $externaldb->SetFetchMode(ADODB_FETCH_ASSOC);
         $externaldb->SetCharSet('utf8');
 

--- a/middlewarelib.php
+++ b/middlewarelib.php
@@ -76,7 +76,7 @@ class Middleware {
             '/\{view_([a-zA-Z][0-9a-zA-Z_]*)\}/i' => $config->dbname . '.View_' . $config->contexto . '_$1',
             '/\{geral_([a-zA-Z][0-9a-zA-Z_]*)\}/i' => $config->dbname . '.View_Geral_$1',
             '/\{table_([a-zA-Z][0-9a-zA-Z_]*)\}/i' => $config->dbname . '.$1',
-            '/\{([a-z][a-z0-9_]*)\}/' => $moodle_prefix.'.$1'); // regexp do moodle, precisa ser o útlimo
+            '/\{([a-z][a-z0-9_]*)\}/' => $moodle_prefix.'$1'); // regexp do moodle, precisa ser o útlimo
 
         // Inicializa conexão com a base de dados
         $db = $this->db_init($config);
@@ -107,7 +107,6 @@ class Middleware {
     public function execute($sql, array $params=null) {
         $rawsql = $this->fix_names($sql);
         list($rawsql, $params) = $this->fix_sql_params($rawsql, $params);
-
         return $this->db->Execute($rawsql, $params);
     }
 

--- a/settings.php
+++ b/settings.php
@@ -16,6 +16,9 @@ if ($hassiteconfig) {
             $roles[$role->shortname] = $role->localname;
         }
 
+        /**
+        * A configuração de grupos de tutoria são armazenadas na tabela "config" do moodle.
+        */
         $ADMIN->add('users', new admin_category('grupostutoria', get_string('grupos_tutoria', 'local_tutores')));
 
         $settings = new admin_settingpage('grupos_tutoria_settings', get_string('grupos_tutoria_settings', 'local_tutores'));


### PR DESCRIPTION
…das)

lib.php:, a forma de pegar a informação foi alterada da variável global do moodle CFG para uma consulta direta no banco de dados. Motivo esse é que o teste behat não possui acesso à essa variável em todos os seus estágios de teste. Deixei em comentário, caso precise desfazer essa modificação.

middlewarelib.php: acredito se tratar de um erro de codificaçao mesmo. Foi retirado o ponto antes da variável $i.